### PR TITLE
Add suppor for type aliases annotation

### DIFF
--- a/src/py_avro_schema/_alias.py
+++ b/src/py_avro_schema/_alias.py
@@ -67,4 +67,6 @@ def register_alias(alias: FQN):
 
 def get_aliases(fqn: str) -> list[str]:
     """Returns the list of aliases for a given type"""
-    return list(_ALIASES.get(fqn) or [])
+    if aliases := _ALIASES.get(fqn):
+        return sorted(aliases)
+    return []

--- a/src/py_avro_schema/_alias.py
+++ b/src/py_avro_schema/_alias.py
@@ -45,6 +45,26 @@ def register_aliases(aliases: list[FQN]):
     return _wrapper
 
 
+def register_alias(alias: FQN):
+    """
+    Decorator to register a single alias for a given type.
+
+    Example::
+        @register_alias(alias="py_avro_schema.OldAddress")
+        class Address(TypedDict):
+            street: str
+            number: int
+    """
+
+    def _wrapper(cls):
+        """Wrapper function that updates the aliases dictionary"""
+        fqn = get_fully_qualified_name(cls)
+        _ALIASES[fqn].add(alias)
+        return cls
+
+    return _wrapper
+
+
 def get_aliases(fqn: str) -> list[str]:
     """Returns the list of aliases for a given type"""
     return list(_ALIASES.get(fqn) or [])

--- a/src/py_avro_schema/_alias.py
+++ b/src/py_avro_schema/_alias.py
@@ -25,12 +25,12 @@ def get_fully_qualified_name(py_type: type) -> str:
     return qualname
 
 
-def register_aliases(aliases: list[FQN]):
+def register_type_aliases(aliases: list[FQN]):
     """
     Decorator to register aliases for a given type.
 
     Example::
-        @register_aliases(aliases=["py_avro_schema.OldAddress"])
+        @register_type_aliases(aliases=["py_avro_schema.OldAddress"])
         class Address(TypedDict):
             street: str
             number: int
@@ -45,12 +45,12 @@ def register_aliases(aliases: list[FQN]):
     return _wrapper
 
 
-def register_alias(alias: FQN):
+def register_type_alias(alias: FQN):
     """
     Decorator to register a single alias for a given type.
 
     Example::
-        @register_alias(alias="py_avro_schema.OldAddress")
+        @register_type_alias(alias="py_avro_schema.OldAddress")
         class Address(TypedDict):
             street: str
             number: int

--- a/src/py_avro_schema/_alias.py
+++ b/src/py_avro_schema/_alias.py
@@ -1,0 +1,50 @@
+"""
+Module to register aliases for Python types
+"""
+
+from collections import defaultdict
+
+FQN = str
+"""Fully qualified name for a Python type"""
+_ALIASES: dict[FQN, set[FQN]] = defaultdict(set)
+"""Maps the FQN of a Python type to a set of aliases"""
+
+
+def get_fully_qualified_name(py_type: type) -> str:
+    """Returns the fully qualified name for a Python type"""
+    module = getattr(py_type, "__module__", None)
+    qualname = getattr(py_type, "__qualname__", py_type.__name__)
+
+    # py-avro-schema does not consider <locals> in the namespace.
+    # we skip it here as well for consistency
+    if module and "<locals>" in qualname:
+        return f"{module}.{py_type.__name__}"
+
+    if module and module not in ("builtins", "__main__"):
+        return f"{module}.{qualname}"
+    return qualname
+
+
+def register_aliases(aliases: list[FQN]):
+    """
+    Decorator to register aliases for a given type.
+
+    Example::
+        @register_aliases(aliases=["py_avro_schema.OldAddress"])
+        class Address(TypedDict):
+            street: str
+            number: int
+    """
+
+    def _wrapper(cls):
+        """Wrapper function that updates the aliases dictionary"""
+        fqn = get_fully_qualified_name(cls)
+        _ALIASES[fqn].update(aliases)
+        return cls
+
+    return _wrapper
+
+
+def get_aliases(fqn: str) -> list[str]:
+    """Returns the list of aliases for a given type"""
+    return list(_ALIASES.get(fqn) or [])

--- a/src/py_avro_schema/_alias.py
+++ b/src/py_avro_schema/_alias.py
@@ -1,5 +1,8 @@
 """
 Module to register aliases for Python types
+
+This module maintains global state via the _ALIASES registry.
+Decorators will modify this state when applied to classes.
 """
 
 from collections import defaultdict
@@ -28,6 +31,8 @@ def get_fully_qualified_name(py_type: type) -> str:
 def register_type_aliases(aliases: list[FQN]):
     """
     Decorator to register aliases for a given type.
+    It allows for compatible schemas following a change type (e.g., a rename), if the type fields do not
+    change in an incompatible way.
 
     Example::
         @register_type_aliases(aliases=["py_avro_schema.OldAddress"])
@@ -48,6 +53,8 @@ def register_type_aliases(aliases: list[FQN]):
 def register_type_alias(alias: FQN):
     """
     Decorator to register a single alias for a given type.
+    It allows for compatible schemas following a change type (e.g., a rename), if the type fields do not
+    change in an incompatible way.
 
     Example::
         @register_type_alias(alias="py_avro_schema.OldAddress")

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -50,6 +50,7 @@ import orjson
 import typeguard
 
 import py_avro_schema._typing
+from py_avro_schema._alias import get_aliases
 
 if TYPE_CHECKING:
     # Pydantic not necessarily required at runtime
@@ -857,6 +858,9 @@ class EnumSchema(NamedSchema):
         }
         if self.namespace is not None:
             enum_schema["namespace"] = self.namespace
+            fqn = f"{self.namespace}.{self.name}"
+            if aliases := get_aliases(fqn):
+                enum_schema["aliases"] = aliases
         if Option.NO_DOC not in self.options:
             doc = _doc_for_class(self.py_type)
             if doc:
@@ -887,6 +891,9 @@ class RecordSchema(NamedSchema):
         }
         if self.namespace is not None:
             record_schema["namespace"] = self.namespace
+            fqn = f"{self.namespace}.{self.name}"
+            if aliases := get_aliases(fqn):
+                record_schema["aliases"] = aliases
         if Option.NO_DOC not in self.options:
             doc = _doc_for_class(self.py_type)
             if doc:

--- a/tests/test_avro_schema.py
+++ b/tests/test_avro_schema.py
@@ -10,11 +10,14 @@
 # specific language governing permissions and limitations under the License.
 
 import dataclasses
+import json
+from typing import TypedDict
 
 import avro.schema
 import orjson
 
 import py_avro_schema as pas
+from py_avro_schema._alias import register_type_alias, register_type_aliases
 
 
 def test_package_has_version():
@@ -43,3 +46,21 @@ def test_dataclass_string_field():
     json_data = pas.generate(PyType)
     assert json_data == orjson.dumps(expected)
     assert avro.schema.parse(json_data)
+
+
+def test_avro_type_aliases():
+    @register_type_aliases(aliases=["test_avro_schema.VeryOldDict", "test_avro_schema.OldDict"])
+    class PyTypedDict(TypedDict):
+        value: str
+
+    json_data = pas.generate(PyTypedDict)
+    assert json.loads(json_data)["aliases"] == ["test_avro_schema.OldDict", "test_avro_schema.VeryOldDict"]
+
+    register_type_alias(alias="test_avro_schema.SuperOldDict")(PyTypedDict)
+    pas.generate.cache_clear()
+    json_data = pas.generate(PyTypedDict)
+    assert json.loads(json_data)["aliases"] == [
+        "test_avro_schema.OldDict",
+        "test_avro_schema.SuperOldDict",
+        "test_avro_schema.VeryOldDict",
+    ]

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -19,6 +19,7 @@ from typing import Annotated, Dict, List, Optional, Tuple
 import pytest
 
 import py_avro_schema as pas
+from py_avro_schema._alias import register_aliases
 from py_avro_schema._testing import assert_schema
 
 
@@ -400,6 +401,7 @@ def test_dataclass_repeated_string_field():
 
 
 def test_dataclass_repeated_enum_field():
+    @register_aliases(aliases=["test_dataclass.OldEnum"])
     class PyTypeEnum(enum.Enum):
         RED = "RED"
         GREEN = "GREEN"
@@ -412,12 +414,15 @@ def test_dataclass_repeated_enum_field():
     expected = {
         "type": "record",
         "name": "PyType",
+        "namespace": "test_dataclass",
         "fields": [
             {
                 "name": "field_child_1",
                 "type": {
                     "type": "enum",
                     "name": "PyTypeEnum",
+                    "namespace": "test_dataclass",
+                    "aliases": ["test_dataclass.OldEnum"],
                     "symbols": [
                         "RED",
                         "GREEN",
@@ -427,11 +432,11 @@ def test_dataclass_repeated_enum_field():
             },
             {
                 "name": "field_child_2",
-                "type": "PyTypeEnum",
+                "type": "test_dataclass.PyTypeEnum",
             },
         ],
     }
-    assert_schema(PyType, expected)
+    assert_schema(PyType, expected, do_auto_namespace=True)
 
 
 def test_self_ref_field():

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -19,7 +19,7 @@ from typing import Annotated, Dict, List, Optional, Tuple
 import pytest
 
 import py_avro_schema as pas
-from py_avro_schema._alias import register_aliases
+from py_avro_schema._alias import register_type_aliases
 from py_avro_schema._testing import assert_schema
 
 
@@ -401,7 +401,7 @@ def test_dataclass_repeated_string_field():
 
 
 def test_dataclass_repeated_enum_field():
-    @register_aliases(aliases=["test_dataclass.OldEnum"])
+    @register_type_aliases(aliases=["test_dataclass.OldEnum"])
     class PyTypeEnum(enum.Enum):
         RED = "RED"
         GREEN = "GREEN"

--- a/tests/test_plain_class.py
+++ b/tests/test_plain_class.py
@@ -15,12 +15,12 @@ from typing import Annotated
 import pytest
 
 import py_avro_schema
-from py_avro_schema._alias import register_aliases
+from py_avro_schema._alias import register_type_aliases
 from py_avro_schema._testing import assert_schema
 
 
 def test_plain_class_with_type_hints():
-    @register_aliases(aliases=["test_plain_class.OldPyType"])
+    @register_type_aliases(aliases=["test_plain_class.OldPyType"])
     class PyType:
         """A port, not using dataclass"""
 

--- a/tests/test_plain_class.py
+++ b/tests/test_plain_class.py
@@ -15,10 +15,12 @@ from typing import Annotated
 import pytest
 
 import py_avro_schema
+from py_avro_schema._alias import register_aliases
 from py_avro_schema._testing import assert_schema
 
 
 def test_plain_class_with_type_hints():
+    @register_aliases(aliases=["test_plain_class.OldPyType"])
     class PyType:
         """A port, not using dataclass"""
 
@@ -33,6 +35,8 @@ def test_plain_class_with_type_hints():
     expected = {
         "type": "record",
         "name": "PyType",
+        "namespace": "test_plain_class",
+        "aliases": ["test_plain_class.OldPyType"],
         "fields": [
             {
                 "name": "name",
@@ -54,7 +58,7 @@ def test_plain_class_with_type_hints():
         ],
     }
 
-    assert_schema(PyType, expected)
+    assert_schema(PyType, expected, do_auto_namespace=True)
 
 
 def test_plain_class_annotated():

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -1,5 +1,6 @@
 from typing import TypedDict
 
+from py_avro_schema._alias import register_aliases
 from py_avro_schema._testing import assert_schema
 
 
@@ -27,6 +28,7 @@ def test_typed_dict():
 
 
 def test_type_dict_nested():
+    @register_aliases(aliases=["test_typed_dict.OldAddress"])
     class Address(TypedDict):
         street: str
         number: int
@@ -39,6 +41,7 @@ def test_type_dict_nested():
     expected = {
         "type": "record",
         "name": "User",
+        "namespace": "test_typed_dict",
         "fields": [
             {
                 "name": "name",
@@ -49,6 +52,8 @@ def test_type_dict_nested():
                 "name": "address",
                 "type": {
                     "name": "Address",
+                    "namespace": "test_typed_dict",
+                    "aliases": ["test_typed_dict.OldAddress"],
                     "type": "record",
                     "fields": [
                         {"name": "street", "type": "string"},
@@ -58,4 +63,4 @@ def test_type_dict_nested():
             },
         ],
     }
-    assert_schema(User, expected)
+    assert_schema(User, expected, do_auto_namespace=True)

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -1,6 +1,6 @@
 from typing import TypedDict
 
-from py_avro_schema._alias import register_alias
+from py_avro_schema._alias import register_type_alias
 from py_avro_schema._testing import assert_schema
 
 
@@ -28,7 +28,7 @@ def test_typed_dict():
 
 
 def test_type_dict_nested():
-    @register_alias("test_typed_dict.OldAddress")
+    @register_type_alias("test_typed_dict.OldAddress")
     class Address(TypedDict):
         street: str
         number: int

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -1,6 +1,6 @@
 from typing import TypedDict
 
-from py_avro_schema._alias import register_aliases
+from py_avro_schema._alias import register_alias
 from py_avro_schema._testing import assert_schema
 
 
@@ -28,7 +28,7 @@ def test_typed_dict():
 
 
 def test_type_dict_nested():
-    @register_aliases(aliases=["test_typed_dict.OldAddress"])
+    @register_alias("test_typed_dict.OldAddress")
     class Address(TypedDict):
         street: str
         number: int


### PR DESCRIPTION
## Context 

One of the common refactoring that breaks persistence is the renaming of a class.
For instance, let us consider the following Python example:

```python
# in localstack.aws.service.sqs.models.py
class Details(TypedDict):
    name: str
    address: str

class User(TypedDict):
    info: dict[str, Details]
```

The schema derived from the `User` type is the following:
```json
{
  "type": "record",
  "name": "User",
  "namespace": "localstack.aws.service.sqs.models",
  "fields": [
    {
      "type": {
        "type": "map",
        "values": {
          "type": "record",
          "name": "Details",
          "namespace": "localstack.aws.service.sqs.models",
          "fields": [
            {
              "type": "string",
              "name": "name"
            },
            {
              "type": "string",
              "name": "address"
            }
          ]
        }
      },
      "name": "info"
    }
  ]
}
```

Let us assume that we rename `Details` to `UserDetails` in a future version of our codebase, i.e., 
```python
# in localstack.aws.service.sqs.models.py
class UserDetails(TypedDict):
    name: str
    address: str

class User(TypedDict):
    info: dict[str, UserDetails]
```

The new schema generated from `User` will now be incompatible with the previous one, despite the underlying data remaining exactly the same.

<details>
<summary>Click to toggle the schema after the code change</summary>

```json
{
  "type": "record",
  "name": "User",
  "namespace": "localstack.aws.service.sqs.models",
  "fields": [
    {
      "type": {
        "type": "map",
        "values": {
          "type": "record",
          "name": "UserDetails",
          "namespace": "localstack.aws.service.sqs.models",
          "fields": [
            {
              "type": "string",
              "name": "name"
            },
            {
              "type": "string",
              "name": "address"
            }
          ]
        }
      },
      "name": "info"
    }
  ]
}
```
</details>

Avro offers a solution to this issue with aliases (see [docs](https://avro.apache.org/docs/1.8.1/spec.html#Aliases)).
In our case, if we add aliases for the reader schema as follows, we would still be compatible with the writer schema above:

```json
{
  "type": "record",
  "name": "User",
  "namespace": "localstack.aws.service.sqs.models",
  "fields": [
    {
      "type": {
        "type": "map",
        "values": {
          "type": "record",
          "name": "UserDetails",
          "namespace": "localstack.aws.service.sqs.models",
          "aliases": ["localstack.aws.service.sqs.models.Details"],
          "fields": [
            {
              "type": "string",
              "name": "name"
            },
            {
              "type": "string",
              "name": "address"
            }
          ]
        }
      },
      "name": "info"
    }
  ]
}
```

## Solution

This PR introduces a decorator that can be used to annotate types with aliases.
Let's use our example before. A developer, after renaming `Details` to `UserDetails`, would annotate the code like that:

```python
# in localstack.aws.service.sqs.models.py
@register_aliases(aliases=["localstack.aws.service.sqs.models.Details"])
class UserDetails(TypedDict):
    name: str
    address: str

class User(TypedDict):
    info: dict[str, Details
```

The framework will pick up this information and generate a compatible schema, exactly like the last schema shown above.


## Misc
Unfortunately, `avro` does not respect aliases as per specs (see [issue](https://issues.apache.org/jira/browse/AVRO-1303)). I've been installing these changes in our code and verified that a schema mismatch is (incorrectly) raised.

Luckily for us, `fastavro` does support aliases. I rewrote our `avro` codecs with `fastavro` (see [PR](https://github.com/localstack/localstack-pro/pull/5223)). Unfortunately, it is not ideal to have two `avro` libraries as dependencies in LocalStack (`avro` is brought in by this project), but I believe we can clean this once the framework gets more stable and definitive.