### PR TITLE
Add support for field aliases

### DIFF
--- a/src/py_avro_schema/_alias.py
+++ b/src/py_avro_schema/_alias.py
@@ -4,7 +4,6 @@ Module to register aliases for Python types
 This module maintains global state via the _ALIASES registry.
 Decorators will modify this state when applied to classes.
 """
-from __future__ import annotations
 
 import dataclasses
 from collections import defaultdict
@@ -15,14 +14,18 @@ FQN = str
 _ALIASES: dict[FQN, set[FQN]] = defaultdict(set)
 """Maps the FQN of a Python type to a set of aliases"""
 
+
 @dataclasses.dataclass
 class Alias:
     """Alias for a record field"""
+
     alias: str
+
 
 @dataclasses.dataclass
 class Aliases:
     """Aliases for a record field"""
+
     aliases: list[str]
 
 

--- a/src/py_avro_schema/_alias.py
+++ b/src/py_avro_schema/_alias.py
@@ -112,5 +112,5 @@ def get_field_aliases_and_actual_type(py_type: Type) -> tuple[list[str] | None, 
         return [], py_type
 
     # If the annotated type is an alias, we extract the aliases and return the actual type
-    aliases = Aliases.aliases if type(annotation) is Aliases else [Alias.alias]
+    aliases = annotation.aliases if type(annotation) is Aliases else [annotation.alias]
     return aliases, actual_type

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -1033,11 +1033,13 @@ class PydanticSchema(RecordSchema):
         default = dataclasses.MISSING if py_field.is_required() else py_field.get_default(call_default_factory=True)
         py_type = self._annotation(name)
         record_name = py_field.alias if Option.USE_FIELD_ALIAS in self.options and py_field.alias else name
+        aliases, actual_type = get_field_aliases_and_actual_type(py_type)
         field_obj = RecordField(
-            py_type=py_type,
+            py_type=actual_type,
             name=record_name,
             namespace=self.namespace_override,
             default=default,
+            aliases=aliases,
             docs=py_field.description or "",
             options=self.options,
         )
@@ -1102,7 +1104,7 @@ class PlainClassSchema(RecordSchema):
             name=py_field.name,
             namespace=self.namespace_override,
             default=default,
-            aliases=[],
+            aliases=aliases,
             options=self.options,
         )
         return field_obj

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -50,7 +50,7 @@ import orjson
 import typeguard
 
 import py_avro_schema._typing
-from py_avro_schema._alias import get_aliases
+from py_avro_schema._alias import get_aliases, get_field_aliases_and_actual_type
 
 if TYPE_CHECKING:
     # Pydantic not necessarily required at runtime
@@ -909,6 +909,7 @@ class RecordField:
         py_type: Type,
         name: str,
         namespace: Optional[str],
+        aliases: list[str] | None = None,
         default: Any = dataclasses.MISSING,
         docs: str = "",
         options: Option = Option(0),
@@ -919,12 +920,16 @@ class RecordField:
         :param py_type:   The Python class or type
         :param name:      Field name
         :param namespace: Avro schema namespace
+        :param aliases:   Aliases for the field
         :param default:   Field default value
         :param docs:      Field documentation or description
         :param options:   Schema generation options
         """
+        if aliases is None:
+            aliases = []
         self.py_type = py_type
         self.name = name
+        self.aliases = aliases or []
         self._namespace = namespace
         self.default = default
         self.docs = docs
@@ -949,6 +954,8 @@ class RecordField:
             "name": self.name,
             "type": self.schema.data(names=names),
         }
+        if self.aliases:
+            field_data["aliases"] = sorted(self.aliases)
         if self.default != dataclasses.MISSING:
             field_data["default"] = self.schema.make_default(self.default)
         if self.docs and Option.NO_DOC not in self.options:
@@ -1121,10 +1128,12 @@ class TypedDictSchema(RecordSchema):
 
     def _record_field(self, py_field: tuple[str, Type]) -> RecordField:
         """Return an Avro record field object for a given TypedDict field"""
+        aliases, actual_type = get_field_aliases_and_actual_type(py_field[1])
         field_obj = RecordField(
-            py_type=py_field[1],
+            py_type=actual_type,
             name=py_field[0],
             namespace=self.namespace_override,
+            aliases=aliases,
             options=self.options,
         )
         return field_obj

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -929,7 +929,7 @@ class RecordField:
             aliases = []
         self.py_type = py_type
         self.name = name
-        self.aliases = aliases or []
+        self.aliases = aliases
         self._namespace = namespace
         self.default = default
         self.docs = docs

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -19,7 +19,7 @@ from typing import Annotated, Dict, List, Optional, Tuple
 import pytest
 
 import py_avro_schema as pas
-from py_avro_schema._alias import register_type_aliases
+from py_avro_schema._alias import Alias, register_type_aliases
 from py_avro_schema._testing import assert_schema
 
 
@@ -842,5 +842,24 @@ def test_sequence_schema_defaults_with_items():
         ],
         "name": "PyType",
         "type": "record",
+    }
+    assert_schema(PyType, expected)
+
+
+def test_field_alias():
+    @dataclasses.dataclass
+    class PyType:
+        field_b: Annotated[str, Alias("field_a")]
+
+    expected = {
+        "type": "record",
+        "name": "PyType",
+        "fields": [
+            {
+                "aliases": ["field_a"],
+                "name": "field_b",
+                "type": "string",
+            }
+        ],
     }
     assert_schema(PyType, expected)

--- a/tests/test_plain_class.py
+++ b/tests/test_plain_class.py
@@ -15,7 +15,7 @@ from typing import Annotated
 import pytest
 
 import py_avro_schema
-from py_avro_schema._alias import register_type_aliases
+from py_avro_schema._alias import Alias, register_type_aliases
 from py_avro_schema._testing import assert_schema
 
 
@@ -80,6 +80,25 @@ def test_plain_class_annotated():
     }
 
     assert_schema(Annotated[PyType, ...], expected)
+
+
+def test_field_alias():
+    class PyType:
+        def __init__(self, name: Annotated[str, Alias("old_name")]):
+            self.name = name
+
+    expected = {
+        "type": "record",
+        "name": "PyType",
+        "fields": [
+            {
+                "aliases": ["old_name"],
+                "name": "name",
+                "type": "string",
+            },
+        ],
+    }
+    assert_schema(PyType, expected)
 
 
 def test_plain_class_no_type_hints():

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -17,6 +17,7 @@ import pydantic
 import pytest
 
 import py_avro_schema as pas
+from py_avro_schema._alias import Alias
 from py_avro_schema._testing import assert_schema
 
 
@@ -490,6 +491,24 @@ def test_annotated_decimal():
                     "precision": 3,
                     "scale": 2,
                 },
+            }
+        ],
+    }
+    assert_schema(PyType, expected)
+
+
+def test_field_alias():
+    class PyType(pydantic.BaseModel):
+        field_a: Annotated[str, Alias("field_b")]
+
+    expected = {
+        "type": "record",
+        "name": "PyType",
+        "fields": [
+            {
+                "aliases": ["field_b"],
+                "name": "field_a",
+                "type": "string",
             }
         ],
     }

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -1,6 +1,6 @@
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
-from py_avro_schema._alias import register_type_alias
+from py_avro_schema._alias import Alias, register_type_alias
 from py_avro_schema._testing import assert_schema
 
 
@@ -64,3 +64,24 @@ def test_type_dict_nested():
         ],
     }
     assert_schema(User, expected, do_auto_namespace=True)
+
+
+def test_field_alias():
+    class User(TypedDict):
+        name: Annotated[str, Alias("username")]
+        age: int
+
+    expected = {
+        "type": "record",
+        "name": "User",
+        "fields": [
+            {
+                "aliases": ["username"],
+                "name": "name",
+                "type": "string",
+            },
+            {"name": "age", "type": "long"},
+        ],
+    }
+
+    assert_schema(User, expected)

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -30,7 +30,7 @@ def test_typed_dict():
 def test_type_dict_nested():
     @register_type_alias("test_typed_dict.OldAddress")
     class Address(TypedDict):
-        street: str
+        street: Annotated[str, Alias("address")]
         number: int
 
     class User(TypedDict):
@@ -56,7 +56,7 @@ def test_type_dict_nested():
                     "aliases": ["test_typed_dict.OldAddress"],
                     "type": "record",
                     "fields": [
-                        {"name": "street", "type": "string"},
+                        {"aliases": ["address"], "name": "street", "type": "string"},
                         {"name": "number", "type": "long"},
                     ],
                 },


### PR DESCRIPTION
### Context

In #1 we introduced the possibility to register type aliases. This is very helpful when a Python type gets renamed or moved to a different module.

Another common model evolution scenario is the [rename of a field](https://www.notion.so/localstack/Rename-a-field-with-alias-24ffc2a2343180848597d087c617d66c?source=copy_link). 
Let us look at a very simple example below, where `info` is simply renamed to `details`.

```python
class User(TypedDict):
   info: dict[str, str]
```
changed to 
```python
class User(TypedDict):
   details: dict[str, str]
```

The evolved `TypedDict` has the following schema which is incompatible with the one before the change.

```json
{
  "type": "record",
  "name": "User",
  "fields": {"name": "details", "type": "map"}
}
```

Avro can natively handle this change if an alias is provided (see [docs](https://avro.apache.org/docs/1.8.1/spec.html#Aliases)), e.g.,:

```json
{
  "type": "record",
  "name": "User",
  "fields": {"name": "details", "type": "map", "aliases", ["info"]}
}
```

### Approach

To support field aliases, we are leveraging the [`Annotated`](https://docs.python.org/3/library/typing.html#typing.Annotated) type.

To specify a field aliases with `Annotated`, one would need to do the following:

```python
class User(TypedDict):
   details: Annotated[dict[str, str], Alias("info")]
```

Whenever our framework detect an `Annotated` type with an `Alias` as metadata, an alias is recorded in the schema.
Generating a schema from the `User` type annotated as described, will generate an `avro` schema with the wanted alias.
