### PR TITLE
Support for enums with invalid symbols

### DIFF
--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -508,3 +508,14 @@ def test_enum_docs():
         "default": "RED",
     }
     assert_schema(PyType, expected, do_doc=True)
+
+
+def test_str_enum_invalid_name():
+    class OriginProtocolPolicy(str, enum.Enum):
+        http_only = "http-only"
+        match_viewer = "match-viewer"
+        https_only = "https-only"
+
+    expected = {"namedString": "OriginProtocolPolicy", "type": "string"}
+
+    assert_schema(OriginProtocolPolicy, expected)


### PR DESCRIPTION
When dealing with `Enums`, Avro lists all the possible symbols in the `symbols` attributes. However, symbols need to match a particular regex (see [docs](https://avro.apache.org/docs/1.9.1/spec.html#Enums)).

This is a problem for a few `StrEnum` that are generated from the boto specs.
For istance, the following class will raise an error because the symbols contain an invalid `-` char.

```python
class OriginProtocolPolicy(StrEnum):
    http_only = "http-only"
    match_viewer = "match-viewer"
    https_only = "https-only"
```

To overcome this issue, we now can use the already available `StrSubclassSchema` when a symbol of an `Enum` is invalid.