### PR TITLE
add priority to the register_schema decorator

### DIFF
--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -140,7 +140,7 @@ _SCHEMA_CLASSES = []
 def register_schema(cls: type | None = None, *, priority: int = 0):
     """
     Decorator to register a class as a known ``Schema``
-    It also accept a priority value to sort the list of schemas. Default schema have 0 priority.
+    It also accept a priority value to sort the list of schemas. Default schemas have priority 0.
 
     Schema classes are instantiated when calling ``schema``. Example use::
 

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -156,8 +156,6 @@ def register_schema(cls: type | None = None, *, priority: int = 0):
         """Wrapper function to attach priority and sort the list of schemas."""
         _cls.__priority = priority
         _SCHEMA_CLASSES.append(_cls)
-        # Sorting at every addition is not very nice, but we do have few schemas, and we record them once.
-        _SCHEMA_CLASSES.sort(key=lambda c: getattr(c, "__priority", 0), reverse=True)
         return _cls
 
     return _wrapper if not cls else _wrapper(cls)
@@ -196,7 +194,7 @@ def _schema_obj(py_type: Type, namespace: Optional[str] = None, options: Option 
     :param options:   Schema generation options.
     """
     # Find concrete Schema subclasses defined in the current module
-    for schema_class in _SCHEMA_CLASSES:
+    for schema_class in sorted(_SCHEMA_CLASSES, key=lambda c: getattr(c, "__priority", 0), reverse=True):
         # Find the first schema class that handles py_type
         schema_obj = schema_class(py_type, namespace=namespace, options=options)  # type: ignore
         if schema_obj:

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -154,7 +154,7 @@ def register_schema(cls: type | None = None, *, priority: int = 0):
 
     def _wrapper(_cls):
         """Wrapper function to attach priority and sort the list of schemas."""
-        _cls.__priority = priority
+        _cls.__py_avro_priority = priority
         _SCHEMA_CLASSES.append(_cls)
         return _cls
 
@@ -194,7 +194,7 @@ def _schema_obj(py_type: Type, namespace: Optional[str] = None, options: Option 
     :param options:   Schema generation options.
     """
     # Find concrete Schema subclasses defined in the current module
-    for schema_class in sorted(_SCHEMA_CLASSES, key=lambda c: getattr(c, "__priority", 0), reverse=True):
+    for schema_class in sorted(_SCHEMA_CLASSES, key=lambda c: getattr(c, "__py_avro_priority", 0)):
         # Find the first schema class that handles py_type
         schema_obj = schema_class(py_type, namespace=namespace, options=options)  # type: ignore
         if schema_obj:


### PR DESCRIPTION
When registering new schemas, we'd like to have the option to sort them in a given order.
For instance, if we register a schema for `BaseStores`, the schema for plain python classes would take the precedence.

Changes:
- optional `priority` parameter to the `register_schema` decorator;
- add a sort when iterating over the schemas.