### PR TITLE
Fix duplicated reference to invalid enums

### DIFF
--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -860,6 +860,13 @@ class EnumSchema(NamedSchema):
             return False
         return True
 
+    def data(self, names: NamesType) -> JSONType:
+        """Return the schema data"""
+        # For invalid enums we don't want to deduplicate the data
+        if not self._is_valid_enum():
+            return self.data_before_deduplication(names=names)
+        return super().data(names)
+
     def data_before_deduplication(self, names: NamesType) -> JSONObj:
         """Return the schema data"""
         if not self._is_valid_enum():

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -8,7 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-
+import dataclasses
 import enum
 import re
 import sys
@@ -519,3 +519,25 @@ def test_str_enum_invalid_name():
     expected = {"namedString": "OriginProtocolPolicy", "type": "string"}
 
     assert_schema(OriginProtocolPolicy, expected)
+
+
+def test_duplicated_invalid_enum():
+    class OriginProtocolPolicy(str, enum.Enum):
+        http_only = "http-only"
+        match_viewer = "match-viewer"
+        https_only = "https-only"
+
+    @dataclasses.dataclass
+    class PyType:
+        enum_one: OriginProtocolPolicy
+        enum_two: OriginProtocolPolicy
+
+    expected = {
+        "type": "record",
+        "name": "PyType",
+        "fields": [
+            {"type": {"type": "string", "namedString": "OriginProtocolPolicy"}, "name": "enum_one"},
+            {"type": {"type": "string", "namedString": "OriginProtocolPolicy"}, "name": "enum_two"},
+        ],
+    }
+    assert_schema(PyType, expected)


### PR DESCRIPTION
This is a follow up of https://github.com/localstack/py-avro-schema/pull/4.

In https://github.com/localstack/py-avro-schema/pull/4, we are using a string primitive type to represent `StrEnum` with invalid symbols. A string type in Avro is not a named record, while `Enum` is. When Avro encounters a named record multiple times, at fist adds the full representation for the record. In the other occurrences, it just refers points to the name of the named record. Such a reference does not exist for invalid enums, since we are using a string record.