### PR TITLE
Add supports for sets

### DIFF
--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -672,6 +672,33 @@ class SequenceSchema(Schema):
 
 
 @register_schema
+class SetSchema(SequenceSchema):
+    """An Avro array schema for a given Python set"""
+
+    @classmethod
+    def handles_type(cls, py_type: type) -> bool:
+        """Whether this schema class can represent a given Python class"""
+        py_type = _type_from_annotated(py_type)
+        origin = get_origin(py_type)
+        return _is_class(origin, collections.abc.MutableSet)
+
+    def __init__(
+        self,
+        py_type: type[collections.abc.MutableSet],
+        namespace: str | None = None,
+        options: Option = Option(0),
+    ):
+        """
+        An Avro array schema for a given Python sequence
+
+        :param py_type:   The Python class to generate a schema for.
+        :param namespace: The Avro namespace to add to schemas.
+        :param options:   Schema generation options.
+        """
+        super().__init__(py_type, namespace=namespace, options=options)  # type: ignore
+
+
+@register_schema
 class DictSchema(Schema):
     """An Avro map schema for a given Python mapping"""
 

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -1148,7 +1148,7 @@ class PlainClassSchema(RecordSchema):
         if field := self.signature_fields.get(name):
             _annotation, _default = field
             if actual_type is _annotation:
-                default = _default
+                default = _default or dataclasses.MISSING
         field_obj = RecordField(
             py_type=actual_type,
             name=name,

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -174,6 +174,12 @@ def test_string_list():
     assert_schema(py_type, expected)
 
 
+def test_string_set():
+    py_type = set[str]
+    expected = {"type": "array", "items": "string"}
+    assert_schema(py_type, expected)
+
+
 def test_string_list_annotated():
     py_type = Annotated[List[str], ...]
     expected = {"type": "array", "items": "string"}
@@ -188,6 +194,12 @@ def test_string_list_lower_list():
 
 def test_int_list():
     py_type = List[int]
+    expected = {"type": "array", "items": "long"}
+    assert_schema(py_type, expected)
+
+
+def test_int_set():
+    py_type = set[int]
     expected = {"type": "array", "items": "long"}
     assert_schema(py_type, expected)
 
@@ -211,6 +223,18 @@ def test_string_sequence():
 def test_string_mutable_sequence():
     py_type = MutableSequence[str]
     expected = {"type": "array", "items": "string"}
+    assert_schema(py_type, expected)
+
+
+def test_string_set_of_set():
+    py_type = set[set[str]]
+    expected = {
+        "type": "array",
+        "items": {
+            "type": "array",
+            "items": "string",
+        },
+    }
     assert_schema(py_type, expected)
 
 


### PR DESCRIPTION
This PR:

- adds Avro support for sets (treated as arrays);
- fixes a small bug when we have `None` as a default for a concrete type (e.g., [here](https://github.com/localstack/localstack/blob/27697a5e448daaab89dd6fc0d9b246b2a94f3b3f/localstack-core/localstack/services/sqs/models.py#L75)). It unlocks schemas creation for SQS, with no code change.