### PR TITLE
Adding schema for typing.Final

### DIFF
--- a/src/py_avro_schema/_alias.py
+++ b/src/py_avro_schema/_alias.py
@@ -7,7 +7,7 @@ Decorators will modify this state when applied to classes.
 
 import dataclasses
 from collections import defaultdict
-from typing import Annotated, Final, Type, get_args, get_origin
+from typing import Annotated, Type, get_args, get_origin
 
 FQN = str
 """Fully qualified name for a Python type"""
@@ -108,10 +108,6 @@ def get_field_aliases_and_actual_type(py_type: Type) -> tuple[list[str] | None, 
     Check if a type contains an alias metadata via `Alias` or `Aliases` as metadata.
     It returns the eventual aliases and the type.
     """
-
-    if get_origin(py_type) is Final:
-        return [], get_args(py_type)[0]
-
     # py_type is not annotated. It can't have aliases
     if get_origin(py_type) is not Annotated:
         return [], py_type

--- a/src/py_avro_schema/_alias.py
+++ b/src/py_avro_schema/_alias.py
@@ -7,7 +7,7 @@ Decorators will modify this state when applied to classes.
 
 import dataclasses
 from collections import defaultdict
-from typing import Annotated, Type, get_args, get_origin
+from typing import Annotated, Final, Type, get_args, get_origin
 
 FQN = str
 """Fully qualified name for a Python type"""
@@ -108,6 +108,10 @@ def get_field_aliases_and_actual_type(py_type: Type) -> tuple[list[str] | None, 
     Check if a type contains an alias metadata via `Alias` or `Aliases` as metadata.
     It returns the eventual aliases and the type.
     """
+
+    if get_origin(py_type) is Final:
+        return [], get_args(py_type)[0]
+
     # py_type is not annotated. It can't have aliases
     if get_origin(py_type) is not Annotated:
         return [], py_type

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -33,6 +33,7 @@ from typing import (
     Annotated,
     Any,
     Dict,
+    Final,
     ForwardRef,
     List,
     Literal,
@@ -376,6 +377,28 @@ class LiteralSchema(Schema):
     def data(self, names: NamesType) -> JSONType:
         """Return the schema data"""
         return self.literal_value_schema.data(names=names)
+
+
+@register_schema
+class FinalSchema(Schema):
+    """An Avro schema for Python ``typing.Final``"""
+
+    def __init__(self, py_type: Type, namespace: Optional[str] = None, options: Option = Option(0)):
+        """An Avro schema for Python ``typing.Final``"""
+        super().__init__(py_type, namespace, options)
+        py_type = _type_from_annotated(py_type)
+        real_type = get_args(py_type)[0]
+        self.real_schema = _schema_obj(real_type, namespace=namespace, options=options)
+
+    def data(self, names: NamesType) -> JSONType:
+        """Return the schema data"""
+        return self.real_schema.data(names=names)
+
+    @classmethod
+    def handles_type(cls, py_type: Type) -> bool:
+        """Whether this schema class can represent a given Python class"""
+        py_type = _type_from_annotated(py_type)
+        return get_origin(py_type) is Final
 
 
 @register_schema

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -387,7 +387,10 @@ class FinalSchema(Schema):
         """An Avro schema for Python ``typing.Final``"""
         super().__init__(py_type, namespace, options)
         py_type = _type_from_annotated(py_type)
-        real_type = get_args(py_type)[0]
+        try:
+            real_type = get_args(py_type)[0]
+        except IndexError:
+            raise TypeError("Can't generate Avro schema from Python typing.Final without a type parameter")
         self.real_schema = _schema_obj(real_type, namespace=namespace, options=options)
 
     def data(self, names: NamesType) -> JSONType:
@@ -398,7 +401,7 @@ class FinalSchema(Schema):
     def handles_type(cls, py_type: Type) -> bool:
         """Whether this schema class can represent a given Python class"""
         py_type = _type_from_annotated(py_type)
-        return get_origin(py_type) is Final
+        return get_origin(py_type) is Final or py_type is Final
 
 
 @register_schema

--- a/tests/test_plain_class.py
+++ b/tests/test_plain_class.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 import re
-from typing import Annotated
+from typing import Annotated, Final
 
 import pytest
 
@@ -160,3 +160,22 @@ def test_type_aliases_future():
 
     expected = {"fields": [{"name": "name", "type": "string"}], "name": "PyClass", "type": "record"}
     assert_schema(PyClass, expected)
+
+
+def test_typing_final():
+
+    class PyType:
+        var: Final[str]
+        field: Final[dict[str, int]]
+
+        def __init__(self):
+            self.var = "Hello World"
+            self.field = {"John": 123}
+
+    expected = {
+        "fields": [{"name": "var", "type": "string"}, {"name": "field", "type": {"type": "map", "values": "long"}}],
+        "name": "PyType",
+        "type": "record",
+    }
+
+    assert_schema(PyType, expected)


### PR DESCRIPTION
While looking at the StepFunctions provider, I realized that our framework does not handle the `typing.Final` annotation.

For instance, for the following code:

```python
class MyType:
   var: typing.Final[str]
```

the schema generation fails since there is no handler for `Final`.

We are fixing this by introducing a schema for `typing.Final` that simply strips out the subscribed type invoke that specific schema.

Closing PNX-474