### PR TITLE
Fix annotated refs when using future annotations for plain classes

### DIFF
--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -1156,8 +1156,13 @@ class PlainClassSchema(RecordSchema):
         super().__init__(py_type, namespace=namespace, options=options)
         py_type = _type_from_annotated(py_type)
 
+        # Try to get resolved type hints, but fall back to raw annotations if there are unresolved forward refs
+        try:
+            type_hints = get_type_hints(py_type, include_extras=True)
+        except NameError:
+            type_hints = py_type.__annotations__
         self.py_fields: list[tuple[str, type]] = []
-        for k, v in py_type.__annotations__.items():
+        for k, v in type_hints.items():
             self.py_fields.append((k, v))
         # We store __init__ parameters with default values. They can be used as defaults for the record.
         self.signature_fields = {

--- a/src/py_avro_schema/_testing.py
+++ b/src/py_avro_schema/_testing.py
@@ -13,6 +13,8 @@
 """
 Test functions
 """
+from __future__ import annotations
+
 import dataclasses
 import difflib
 from typing import Dict, Type, Union
@@ -57,3 +59,10 @@ class PyType:
     """For testing"""
 
     field_a: str
+
+Name = str
+
+class PyClass:
+    """For testing"""
+
+    name: Name

--- a/src/py_avro_schema/_testing.py
+++ b/src/py_avro_schema/_testing.py
@@ -13,8 +13,6 @@
 """
 Test functions
 """
-from __future__ import annotations
-
 import dataclasses
 import difflib
 from typing import Dict, Type, Union
@@ -59,10 +57,3 @@ class PyType:
     """For testing"""
 
     field_a: str
-
-Name = str
-
-class PyClass:
-    """For testing"""
-
-    name: Name

--- a/tests/models/forward.py
+++ b/tests/models/forward.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+Name = str
+
+
+class PyClass:
+    """For testing imports with future annotations"""
+
+    name: Name

--- a/tests/test_plain_class.py
+++ b/tests/test_plain_class.py
@@ -18,6 +18,7 @@ import py_avro_schema
 from py_avro_schema._alias import Alias, Opaque, register_type_aliases
 from py_avro_schema._testing import assert_schema
 
+
 def test_plain_class_with_type_hints():
     @register_type_aliases(aliases=["test_plain_class.OldPyType"])
     class PyType:
@@ -155,7 +156,7 @@ def test_type_aliases():
 
 
 def test_type_aliases_future():
-    from py_avro_schema._testing import PyClass
+    from tests.models.forward import PyClass
 
     expected = {"fields": [{"name": "name", "type": "string"}], "name": "PyClass", "type": "record"}
     assert_schema(PyClass, expected)

--- a/tests/test_plain_class.py
+++ b/tests/test_plain_class.py
@@ -18,7 +18,6 @@ import py_avro_schema
 from py_avro_schema._alias import Alias, Opaque, register_type_aliases
 from py_avro_schema._testing import assert_schema
 
-
 def test_plain_class_with_type_hints():
     @register_type_aliases(aliases=["test_plain_class.OldPyType"])
     class PyType:
@@ -143,3 +142,20 @@ def test_opaque_field():
 
     expected = {"fields": [{"name": "details", "type": "string"}], "name": "PyType", "type": "record"}
     assert_schema(PyType, expected)
+
+
+def test_type_aliases():
+    Name = str
+
+    class PyClass:
+        name: Name
+
+    expected = {"fields": [{"name": "name", "type": "string"}], "name": "PyClass", "type": "record"}
+    assert_schema(PyClass, expected)
+
+
+def test_type_aliases_future():
+    from py_avro_schema._testing import PyClass
+
+    expected = {"fields": [{"name": "name", "type": "string"}], "name": "PyType", "type": "record"}
+    assert_schema(PyClass, expected)

--- a/tests/test_plain_class.py
+++ b/tests/test_plain_class.py
@@ -157,5 +157,5 @@ def test_type_aliases():
 def test_type_aliases_future():
     from py_avro_schema._testing import PyClass
 
-    expected = {"fields": [{"name": "name", "type": "string"}], "name": "PyType", "type": "record"}
+    expected = {"fields": [{"name": "name", "type": "string"}], "name": "PyClass", "type": "record"}
     assert_schema(PyClass, expected)


### PR DESCRIPTION
While playing with the framework, I did realize that generating the schema from plain classes was not working with `from __future__ import annotations`, as this import defers the evaluation at runtime and keeps the annotations as strings.

In this PR we use `get_type_hints` instead of fetching the raw annotations to circumvent the problem.
Added a reproducible test.

Fixes PNX-479