### PR TITLE
Improve schemas for non-total TypedDict

### DIFF
--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -131,6 +131,12 @@ class Option(enum.Flag):
     #: See https://docs.pydantic.dev/dev/api/fields/#pydantic.fields.Field
     USE_FIELD_ALIAS = enum.auto()
 
+    #: TypedDict marked with ``total=False`` are valid structures when a field is missing. When of the field is also
+    # optional, we need to have a way to distinguish between a `None` and a non-set field. With this option, the type
+    # of each field is extended with `string`. This way, clients can add markers (e.g., `__td_missing__`) to discern
+    # the two cases.
+    MARK_NON_TOTAL_TYPED_DICTS = enum.auto()
+
 
 JSON_OPTIONS = [opt for opt in Option if opt.name and opt.name.startswith("JSON_")]
 
@@ -1261,7 +1267,7 @@ class TypedDictSchema(RecordSchema):
         """Return an Avro record field object for a given TypedDict field"""
         aliases, actual_type = get_field_aliases_and_actual_type(py_field[1])
 
-        if not self.is_total:
+        if Option.MARK_NON_TOTAL_TYPED_DICTS in self.options and not self.is_total:
             # If a TypedDict is marked as total=None, it does not need to contain all the field. However, we need to
             # be able to distinguish between the fields that are missing from the ones that are present but set to None.
             # To do that, we extend the original type with str. We will later add a special string

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Annotated, TypedDict
 
 from py_avro_schema._alias import Alias, register_type_alias
@@ -88,10 +89,13 @@ def test_field_alias():
 
 
 def test_non_total_typed_dict():
+    class Opt(StrEnum):
+        val = "invalid-val"
 
     class PyType(TypedDict, total=False):
         name: str
         age: int | None
+        opt: Opt | None
 
     expected = {
         "type": "record",
@@ -99,10 +103,10 @@ def test_non_total_typed_dict():
         "fields": [
             {
                 "name": "name",
-                "type":"string",
+                "type": "string",
             },
             {"name": "age", "type": ["long", "null", "string"]},
-        ]
+            {"name": "opt", "type": [{"namedString": "Opt", "type": "string"}, "null"]},
+        ],
     }
     assert_schema(PyType, expected)
-

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -95,6 +95,7 @@ def test_non_total_typed_dict():
 
     class PyType(TypedDict, total=False):
         name: str
+        nickname: str | None
         age: int | None
         opt: Opt | None
 
@@ -106,6 +107,7 @@ def test_non_total_typed_dict():
                 "name": "name",
                 "type": "string",
             },
+            {"name": "nickname", "type": ["string", "null"]},
             {"name": "age", "type": ["long", "null", "string"]},
             {"name": "opt", "type": [{"namedString": "Opt", "type": "string"}, "null"]},
         ],

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -85,3 +85,24 @@ def test_field_alias():
     }
 
     assert_schema(User, expected)
+
+
+def test_non_total_typed_dict():
+
+    class PyType(TypedDict, total=False):
+        name: str
+        age: int | None
+
+    expected = {
+        "type": "record",
+        "name": "PyType",
+        "fields": [
+            {
+                "name": "name",
+                "type":"string",
+            },
+            {"name": "age", "type": ["long", "null", "string"]},
+        ]
+    }
+    assert_schema(PyType, expected)
+

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
 from typing import Annotated, TypedDict
 
+import py_avro_schema as pas
 from py_avro_schema._alias import Alias, register_type_alias
 from py_avro_schema._testing import assert_schema
 
@@ -109,4 +110,4 @@ def test_non_total_typed_dict():
             {"name": "opt", "type": [{"namedString": "Opt", "type": "string"}, "null"]},
         ],
     }
-    assert_schema(PyType, expected)
+    assert_schema(PyType, expected, options=pas.Option.MARK_NON_TOTAL_TYPED_DICTS)


### PR DESCRIPTION
`TypedDicts` in Python can be marked with `total=None`. This means that omitting a field still results in a valid structure.
It gets trickier when non-total `TypedDicts` have also nullable fields.

For instance, imagine the following structure:

```python
class PyType(TypedDict, total=False):
    height: int | None
    weight: int | None
```

The resulting schema would be something like that:

```json
{
  "type": "record",
  "name": "PyType",
  "fields": [
    {
      "name": "height",
      "type": [
        "long",
        "null"
      ]
    },
    {
      "name": "weight",
      "type": [
        "long",
        "null"
      ]
    }
  ]
}
```

Now, imagine the two following objects.

```python
obj = PyType(height=180, weight=None)
obj2 = PyType(height=180)
```

The schema would fit both the Avro representation, but does not let us distinguish the case in which `weight` is explicitly set to `None` from the case in which it is not set at all.

With this PR, we extend the types of the fields of a non-total TypedDict with `string`. This is going to be useful for all clients to mark a field as explicitly missing. Eveyrhing would make more sense if you look at the mentioned PR using this feature.

Addresses PNX-545