### PR TITLE
Extend as JSON schema to include list[Any]

### DIFF
--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -405,7 +405,7 @@ class FinalSchema(Schema):
 
 
 @register_schema
-class DictAsJSONSchema(Schema):
+class TypeAsJSONSchema(Schema):
     """
     An Avro string schema representing a Python Dict[str, Any], List[Dict[str, Any]] or List[Any] assuming
     JSON serialization

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -406,12 +406,15 @@ class FinalSchema(Schema):
 
 @register_schema
 class DictAsJSONSchema(Schema):
-    """An Avro string schema representing a Python Dict[str, Any] or List[Dict[str, Any]] assuming JSON serialization"""
+    """
+    An Avro string schema representing a Python Dict[str, Any], List[Dict[str, Any]] or List[Any] assuming
+    JSON serialization
+    """
 
     @classmethod
     def handles_type(cls, py_type: Type) -> bool:
         """Whether this schema class can represent a given Python class"""
-        return _is_dict_str_any(py_type) or _is_list_dict_str_any(py_type)
+        return is_logically_json(py_type)
 
     def data(self, names: NamesType) -> JSONObj:
         """Return the schema data"""
@@ -1278,6 +1281,17 @@ def _is_list_dict_str_any(py_type: Type) -> bool:
         return inspect.isclass(origin) and issubclass(origin, list) and _is_dict_str_any(args[0])
     else:
         return False
+
+
+def _is_list_any(py_type: Type) -> bool:
+    """Return whether a given type is ``List[Any]``"""
+    origin = get_origin(py_type)
+    return inspect.isclass(origin) and issubclass(origin, list) and get_args(py_type) == (Any,)
+
+
+def is_logically_json(py_type: Type) -> bool:
+    """Returns whether a given type is logically a JSON and can be serialized as such"""
+    return _is_list_any(py_type) or _is_list_dict_str_any(py_type) or _is_dict_str_any(py_type)
 
 
 def _is_class(py_type: Any, of_types: Union[Type, Tuple[Type, ...]], include_subclasses: bool = True) -> bool:

--- a/tests/test_logicals.py
+++ b/tests/test_logicals.py
@@ -285,3 +285,9 @@ def test_list_json_logical_bytes_field():
         "logicalType": "json",
     }
     assert_schema(py_type, expected)
+
+
+def test_list_json_logical_list_any():
+    py_type = List[Any]
+    expected = {"type": "bytes", "logicalType": "json"}
+    assert_schema(py_type, expected)


### PR DESCRIPTION
This framework has the feature of reducing specific types (`dict[str, Any]` and `list[dict[str, Any]`) to a `string` (or `bytes`), assuming the fields are dumped to JSON.

With this PR, we also extend the same behavior to `list[Any]`, as we did find many occurrences in LocalStack when this would be very useful!