### PR TITLE
Add optional field for Unions to track types at runtime

### DIFF
--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -137,6 +137,9 @@ class Option(enum.Flag):
     # the two cases.
     MARK_NON_TOTAL_TYPED_DICTS = enum.auto()
 
+    #: Adds a _avro_type field to the record schemas that contains the name of the class
+    ADD_TYPE_FIELD = enum.auto()
+
 
 JSON_OPTIONS = [opt for opt in Option if opt.name and opt.name.startswith("JSON_")]
 
@@ -1105,6 +1108,11 @@ class DataclassSchema(RecordSchema):
 
         return field_obj
 
+    def data_before_deduplication(self, names: NamesType) -> JSONObj:
+        data = super().data_before_deduplication(names)
+        if Option.ADD_TYPE_FIELD in self.options:
+            data["fields"].append({"name": "_avro_type", "type": ["null", "string"]})
+        return data
 
 @register_schema
 class PydanticSchema(RecordSchema):
@@ -1238,6 +1246,12 @@ class PlainClassSchema(RecordSchema):
             options=self.options,
         )
         return field_obj
+
+    def data_before_deduplication(self, names: NamesType) -> JSONObj:
+        data = super().data_before_deduplication(names)
+        if Option.ADD_TYPE_FIELD in self.options:
+            data["fields"].append({"name": "_avro_type", "type": ["null", "string"]})
+        return data
 
 
 @register_schema

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -1109,6 +1109,7 @@ class DataclassSchema(RecordSchema):
         return field_obj
 
     def data_before_deduplication(self, names: NamesType) -> JSONObj:
+        """Return the schema data"""
         data = super().data_before_deduplication(names)
         if Option.ADD_TYPE_FIELD in self.options:
             data["fields"].append({"name": "_avro_type", "type": ["null", "string"]})
@@ -1249,6 +1250,7 @@ class PlainClassSchema(RecordSchema):
         return field_obj
 
     def data_before_deduplication(self, names: NamesType) -> JSONObj:
+        """Return the schema data"""
         data = super().data_before_deduplication(names)
         if Option.ADD_TYPE_FIELD in self.options:
             data["fields"].append({"name": "_avro_type", "type": ["null", "string"]})

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -72,6 +72,8 @@ JSONType = Union[JSONStr, JSONObj, JSONArray]
 
 NamesType = List[str]
 
+RUNTIME_TYPE_KEY = "_runtime_type"
+
 
 class TypeNotSupportedError(TypeError):
     """Error raised when a Avro schema cannot be generated for a given Python type"""
@@ -137,8 +139,8 @@ class Option(enum.Flag):
     # the two cases.
     MARK_NON_TOTAL_TYPED_DICTS = enum.auto()
 
-    #: Adds a _avro_type field to the record schemas that contains the name of the class
-    ADD_TYPE_FIELD = enum.auto()
+    #: Adds a _runtime_type field to the record schemas that contains the name of the class
+    ADD_RUNTIME_TYPE_FIELD = enum.auto()
 
 
 JSON_OPTIONS = [opt for opt in Option if opt.name and opt.name.startswith("JSON_")]
@@ -1111,8 +1113,8 @@ class DataclassSchema(RecordSchema):
     def data_before_deduplication(self, names: NamesType) -> JSONObj:
         """Return the schema data"""
         data = super().data_before_deduplication(names)
-        if Option.ADD_TYPE_FIELD in self.options:
-            data["fields"].append({"name": "_avro_type", "type": ["null", "string"]})
+        if Option.ADD_RUNTIME_TYPE_FIELD in self.options:
+            data["fields"].append({"name": RUNTIME_TYPE_KEY, "type": ["null", "string"]})
         return data
 
 
@@ -1252,8 +1254,8 @@ class PlainClassSchema(RecordSchema):
     def data_before_deduplication(self, names: NamesType) -> JSONObj:
         """Return the schema data"""
         data = super().data_before_deduplication(names)
-        if Option.ADD_TYPE_FIELD in self.options:
-            data["fields"].append({"name": "_avro_type", "type": ["null", "string"]})
+        if Option.ADD_RUNTIME_TYPE_FIELD in self.options:
+            data["fields"].append({"name": RUNTIME_TYPE_KEY, "type": ["null", "string"]})
         return data
 
 

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -1114,6 +1114,7 @@ class DataclassSchema(RecordSchema):
             data["fields"].append({"name": "_avro_type", "type": ["null", "string"]})
         return data
 
+
 @register_schema
 class PydanticSchema(RecordSchema):
     """An Avro record schema for a given Pydantic model class"""

--- a/tests/test_avro_schema.py
+++ b/tests/test_avro_schema.py
@@ -76,7 +76,7 @@ def test_add_type_field():
         "name": "PyType",
         "fields": [
             {"name": "field", "type": "string"},
-            {"name": "_avro_type", "type": ["null", "string"]},
+            {"name": "_runtime_type", "type": ["null", "string"]},
         ],
     }
-    assert_schema(PyType, expected, options=pas.Option.ADD_TYPE_FIELD)
+    assert_schema(PyType, expected, options=pas.Option.ADD_RUNTIME_TYPE_FIELD)

--- a/tests/test_avro_schema.py
+++ b/tests/test_avro_schema.py
@@ -18,6 +18,7 @@ import orjson
 
 import py_avro_schema as pas
 from py_avro_schema._alias import register_type_alias, register_type_aliases
+from py_avro_schema._testing import assert_schema
 
 
 def test_package_has_version():
@@ -64,3 +65,18 @@ def test_avro_type_aliases():
         "test_avro_schema.SuperOldDict",
         "test_avro_schema.VeryOldDict",
     ]
+
+
+def test_add_type_field():
+    class PyType:
+        field: str
+
+    expected = {
+        "type": "record",
+        "name": "PyType",
+        "fields": [
+            {"name": "field", "type": "string"},
+            {"name": "_avro_type", "type": ["null", "string"]},
+        ],
+    }
+    assert_schema(PyType, expected, options=pas.Option.ADD_TYPE_FIELD)


### PR DESCRIPTION
## Problem

A `Union`, by definition, allows multiple types for a given field.
This is problematic when we have to deserialize a `Union` back to its original Python type.
Assume the following example:

```python
class A: ...
class B: ...

field: A | B = A()
```

At serialization time, we can serialize the instance of `A` as a serializable Avro record (i.e., its flattened dictionary).
However, at deserialization time, when we get back such a dictionary, we only know from the annotations that such a record can be either `A` or `B`. Therefore, we can't decide which class to instantiate.

## Solution

This PR adds a special option that adds a new optional field called `_avro_type`. When deserializing a `Union`, clients can put in this field the runtime type of the `Union`. This way, the record itself will contain the information about the correct type to create at deserialization time.
