### PR TITLE
fix Enum validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ docs = [
     "sphinx-rtd-theme",
 ]
 testing = [
-    "packaging",  # A test case uses packaging.version.Version
     "pydantic>=2",
     "pytest",
     "pytest-cov",

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -46,11 +46,9 @@ from typing import (
     get_type_hints,
 )
 
-import avro.name
 import more_itertools
 import orjson
 import typeguard
-from avro.errors import InvalidName
 
 import py_avro_schema._typing
 from py_avro_schema._alias import get_aliases, get_field_aliases_and_actual_type
@@ -73,6 +71,7 @@ JSONType = Union[JSONStr, JSONObj, JSONArray]
 NamesType = List[str]
 
 RUNTIME_TYPE_KEY = "_runtime_type"
+SYMBOL_REGEX = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
 class TypeNotSupportedError(TypeError):
@@ -930,12 +929,14 @@ class EnumSchema(NamedSchema):
             raise TypeError(f"Avro enum schema members must be strings. {py_type} uses {symbol_types} values.")
 
     def _is_valid_enum(self) -> bool:
-        """Checks if all the symbols of the enum are valid Avro names."""
-        try:
-            for _symbol in self.symbols:
-                avro.name.validate_basename(_symbol)
-        except InvalidName:
-            return False
+        """
+        Checks if all the symbols of the enum are valid Avro names.
+        Based on `fastavro._schema_py._validate_enum_symbols`
+        """
+        for _symbol in self.symbols:
+            if not isinstance(_symbol, str) or not SYMBOL_REGEX.fullmatch(_symbol):
+                return False
+
         return True
 
     def data(self, names: NamesType) -> JSONType:

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -91,6 +91,7 @@ class Option(enum.Flag):
     JSON_INDENT_2 = orjson.OPT_INDENT_2
 
     #: Sort keys in JSON data
+
     JSON_SORT_KEYS = orjson.OPT_SORT_KEYS
 
     #: Append a newline character at the end of the JSON data

--- a/src/py_avro_schema/_testing.py
+++ b/src/py_avro_schema/_testing.py
@@ -13,6 +13,7 @@
 """
 Test functions
 """
+
 import dataclasses
 import difflib
 from typing import Dict, Type, Union

--- a/src/py_avro_schema/_typing.py
+++ b/src/py_avro_schema/_typing.py
@@ -13,6 +13,7 @@
 """
 Additional type hint classes etc
 """
+
 import dataclasses
 import decimal
 from typing import _GenericAlias  # type: ignore

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -65,9 +65,12 @@ def test_str_subclass_namespaced():
 
 
 def test_str_subclass_other_classes():
-    import packaging.version
+    class MyTestClass:
+        def capitalize(self):
+            return self
 
-    class PyType(packaging.version.Version, str): ...
+    class PyType(MyTestClass, str): ...
+
 
     expected = {
         "type": "string",

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -71,7 +71,6 @@ def test_str_subclass_other_classes():
 
     class PyType(MyTestClass, str): ...
 
-
     expected = {
         "type": "string",
         "namedString": "PyType",

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -545,6 +545,16 @@ def test_str_enum_invalid_name():
     assert_schema(OriginProtocolPolicy, expected)
 
 
+def test_str_enum_invalid_name_with_dot():
+    class StateReasonCode(enum.StrEnum):
+        FunctionError_ExtensionInitError = "FunctionError.ExtensionInitError"
+        FunctionError_InvalidEntryPoint = "FunctionError.InvalidEntryPoint"
+
+    expected = {"namedString": "StateReasonCode", "type": "string"}
+
+    assert_schema(StateReasonCode, expected)
+
+
 def test_duplicated_invalid_enum():
     class OriginProtocolPolicy(str, enum.Enum):
         http_only = "http-only"


### PR DESCRIPTION
We had an issue with Enum symbols which would contain ..

This is because the base avro validation also use the validation for validating full names, which allow . characters.

I've used the same validation as fastavro, as this is what we use to encode/decode data, to make sure the validation will pass 👍

Also fixed a test due to CI error which probably stem from an update in `packaging.version`: `class PyType(packaging.version.Version, str): ...` has a type conflict 