### PR TITLE
Add __td_missing__ marker as default value for non-total TypedDict

### DIFF
--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -1289,12 +1289,17 @@ class TypedDictSchema(RecordSchema):
         """Return an Avro record field object for a given TypedDict field"""
         aliases, actual_type = get_field_aliases_and_actual_type(py_field[1])
 
+        default = dataclasses.MISSING
         if Option.MARK_NON_TOTAL_TYPED_DICTS in self.options and not self.is_total:
             # If a TypedDict is marked as total=False, it does not need to contain all the field. However, we need to
             # be able to distinguish between the fields that are missing from the ones that are present but set to None.
             # To do that, we extend the original type with str. We will later add a special string
             # (e.g., __td_missing__) as a marker at deserialization time.
             actual_type = Union[actual_type, str]  # type: ignore
+            if _is_optional(actual_type):
+                # Note: this works since this schema does not implement `make_default` and the base implementation
+                # simply return the provided type (None in this case).
+                default = None  # type: ignore
         elif _is_not_required(actual_type):
             # A field can be marked with typing.NotRequired even in a TypedDict with is not marked with total=False.
             # Similarly as above, we extend the wrapped type with string.
@@ -1305,6 +1310,7 @@ class TypedDictSchema(RecordSchema):
             name=py_field[0],
             namespace=self.namespace_override,
             aliases=aliases,
+            default=default,
             options=self.options,
         )
         return field_obj
@@ -1319,6 +1325,14 @@ def _doc_for_class(py_type: Type) -> str:
         return doc
     else:
         return ""
+
+
+def _is_optional(py_type: Type) -> bool:
+    """Given a Union of types, checks if None is one of those"""
+    try:
+        return type(None) in get_args(py_type)
+    except Exception:
+        return False
 
 
 def _is_not_required(py_type: Type) -> bool:

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -90,23 +90,40 @@ def test_field_alias():
 
 
 def test_non_total_typed_dict():
-    class Opt(StrEnum):
+    class InvalidEnumSymbol(StrEnum):
         val = "invalid-val"
+
+    class ValidEnumSymbol(StrEnum):
+        val = "valid_val"
 
     class PyType(TypedDict, total=False):
         name: str
         nickname: str | None
         age: int | None
-        opt: Opt | None
+        invalid: InvalidEnumSymbol | None
+        valid: ValidEnumSymbol | None
 
     expected = {
         "type": "record",
         "name": "PyType",
         "fields": [
             {"name": "name", "type": "string"},
-            {"name": "nickname", "type": ["null", "string"], "default": None},
-            {"name": "age", "type": ["null", "long", "string"], "default": None},
-            {"name": "opt", "type": ["null", {"namedString": "Opt", "type": "string"}], "default": None},
+            {"name": "nickname", "type": ["string", "null"], "default": "__td_missing__"},
+            {"name": "age", "type": ["string", "long", "null"], "default": "__td_missing__"},
+            {
+                "name": "invalid",
+                "type": [{"namedString": "InvalidEnumSymbol", "type": "string"}, "null"],
+                "default": "__td_missing__",
+            },
+            {
+                "default": "__td_missing__",
+                "name": "valid",
+                "type": [
+                    "string",
+                    {"default": "valid_val", "name": "ValidEnumSymbol", "symbols": ["valid_val"], "type": "enum"},
+                    "null",
+                ],
+            },
         ],
     }
     assert_schema(PyType, expected, options=pas.Option.MARK_NON_TOTAL_TYPED_DICTS)

--- a/tests/test_typed_dict.py
+++ b/tests/test_typed_dict.py
@@ -104,9 +104,9 @@ def test_non_total_typed_dict():
         "name": "PyType",
         "fields": [
             {"name": "name", "type": "string"},
-            {"name": "nickname", "type": ["string", "null"]},
-            {"name": "age", "type": ["long", "null", "string"]},
-            {"name": "opt", "type": [{"namedString": "Opt", "type": "string"}, "null"]},
+            {"name": "nickname", "type": ["null", "string"], "default": None},
+            {"name": "age", "type": ["null", "long", "string"], "default": None},
+            {"name": "opt", "type": ["null", {"namedString": "Opt", "type": "string"}], "default": None},
         ],
     }
     assert_schema(PyType, expected, options=pas.Option.MARK_NON_TOTAL_TYPED_DICTS)


### PR DESCRIPTION
## Problem

In LocalStack, we often have to serialize non-total `TypedDict` with optional keys. These structures are generated from the specs and receive weekly updates.

Since the specs aim at being backward compatible, when these structures change, they usually get new optional keys.
`AvailabilityZone` in [this change](https://github.com/localstack/localstack/pull/13778/changes#diff-034a86399d607f85918fa85a6e1867f519586f671105d38ae4da01dee60ddfe6R6390) is an example.

Within Avro, a change like that is not backward compatible, as a new value without a default is being added. Therefore, this would require some sort of migration. However, we might argue that these types of changes are, in fact, backwards compatible by default.

## Solution

With non-total `TypedDict`, we already extend the type of the keys with `str`. This allows the serialization layer to put a sentinel value `__td_missing__` to the keys that are absent from the dictionary (to distinguish them from the present keys with `None` value).

The overall idea is to use the `__td_missing__` marker as the default value for these `TypedDict`. The new Avro schemas will remain backward compatible, and the serializer will ignore those keys if not set.