### PR TITLE
add runtime type for wrapped records

### DIFF
--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -312,16 +312,19 @@ class Schema(abc.ABC):
         if fullname in names:
             return fullname
         names.append(fullname)
+
+        fields = [
+            {"name": REF_ID_KEY, "type": ["null", "long"], "default": None},
+            {"name": REF_DATA_KEY, "type": inner_schema},
+        ]
+        if Option.ADD_RUNTIME_TYPE_FIELD in self.options:
+            fields.append({"name": RUNTIME_TYPE_KEY, "type": ["null", "string"]})
+
         record_schema = {
             "type": "record",
             "name": record_name,
-            "fields": [
-                {"name": REF_ID_KEY, "type": ["null", "long"], "default": None},
-                {"name": REF_DATA_KEY, "type": inner_schema},
-            ],
+            "fields": fields,
         }
-        if Option.ADD_RUNTIME_TYPE_FIELD in self.options:
-            record_schema["fields"].append({"name": RUNTIME_TYPE_KEY, "type": ["null", "string"]})
 
         if self.namespace:
             record_schema["namespace"] = self.namespace

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -320,6 +320,9 @@ class Schema(abc.ABC):
                 {"name": REF_DATA_KEY, "type": inner_schema},
             ],
         }
+        if Option.ADD_RUNTIME_TYPE_FIELD in self.options:
+            record_schema["fields"].append({"name": RUNTIME_TYPE_KEY, "type": ["null", "string"]})
+
         if self.namespace:
             record_schema["namespace"] = self.namespace
         return record_schema

--- a/tests/test_avro_schema.py
+++ b/tests/test_avro_schema.py
@@ -80,3 +80,17 @@ def test_add_type_field():
         ],
     }
     assert_schema(PyType, expected, options=pas.Option.ADD_RUNTIME_TYPE_FIELD)
+
+
+def test_add_type_field_on_wrapped_record():
+    py_type = list[str]
+    expected = {
+        "type": "record",
+        "name": "StrList",
+        "fields": [
+            {"name": "__id", "type": ["null", "long"], "default": None},
+            {"name": "__data", "type": {"type": "array", "items": "string"}},
+            {"name": "_runtime_type", "type": ["null", "string"]},
+        ],
+    }
+    assert_schema(py_type, expected, options=pas.Option.WRAP_INTO_RECORDS | pas.Option.ADD_RUNTIME_TYPE_FIELD)


### PR DESCRIPTION
While using the new wrapped records, I fell upon the following case : field: str | list[str]. Because we now wrapped such list in records, we need to add the Runtime Type to make sure we can serialize this type properly, and deserialize it back (understand it is a wrapped record when reading it)

This adds it to the schema so the serde logic can make use of it 👍

note: the weird order is because of this linting issue:  https://github.com/localstack/py-avro-schema/actions/runs/22366726525/job/64734602358

Not sure if we need to configure mypy to be less strict, but it wouldn't let me call `append` on the `fields` value of the dict 🤷 