### PR TITLE
Deterministic default for `datetime` strings.

### DIFF
--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -255,6 +255,15 @@ _AVRO_NAME_PATTERN = re.compile(r"^[A-Za-z]([A-Za-z0-9_])*$")
 _UUID_PATTERN = re.compile(r"^[0-9a-f]{8}(?:-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?$", re.IGNORECASE)
 
 
+def is_valid_datetime(string: str) -> bool:
+    """Checks is a given string is a valid datetime timestamp"""
+    try:
+        datetime.datetime.fromisoformat(string)
+        return True
+    except ValueError:
+        return False
+
+
 def validate_name(value: str) -> str:
     """Validate (and return) whether a given string is a valid Avro name"""
     if not re.match(_AVRO_NAME_PATTERN, value):
@@ -1186,7 +1195,7 @@ class RecordField:
             if (
                 Option.DETERMINISTIC_DEFAULTS in self.options
                 and isinstance(default_value, str)
-                and _UUID_PATTERN.match(default_value)
+                and (_UUID_PATTERN.match(default_value) or is_valid_datetime(default_value))
             ):
                 default_value = ""
             field_data["default"] = default_value

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -941,3 +941,28 @@ def test_deterministic_defaults_uuid_str():
         ],
     }
     assert_schema(PyType, expected, options=pas.Option.DETERMINISTIC_DEFAULTS)
+
+
+def test_deterministic_defaults_timestamp():
+
+    def timestamp_millis() -> str:
+        microsecond_time = datetime.datetime.now(tz=datetime.UTC)
+        microsecond_time = microsecond_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        return microsecond_time[:-4] + microsecond_time[-1]
+
+    @dataclasses.dataclass
+    class PyType:
+        time: str = dataclasses.field(default_factory=lambda: timestamp_millis())
+
+    expected = {
+        "type": "record",
+        "name": "PyType",
+        "fields": [
+            {
+                "name": "time",
+                "type": "string",
+                "default": "",
+            },
+        ],
+    }
+    assert_schema(PyType, expected, options=pas.Option.DETERMINISTIC_DEFAULTS)


### PR DESCRIPTION
Extension of https://github.com/localstack/py-avro-schema/pull/18.

We want to use a deterministic default for strings that come from `datetime`.
